### PR TITLE
Email confirmation was not filled out by the script

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,6 +153,7 @@ async function bookTermin() {
             await Promise.all([
               page.waitForSelector("input#familyName"),
               page.waitForSelector("input#email"),
+              page.waitForSelector("input#emailequality"),
               page.waitForSelector('select[name="surveyAccepted"]'),
               page.waitForSelector("input#agbgelesen"),
               page.waitForSelector("button#register_submit.btn"),
@@ -178,6 +179,11 @@ async function bookTermin() {
           ),
           bookingPage.$eval(
             "input#email",
+            (el, config) => (el.value = config.email),
+            config
+          ),
+          bookingPage.$eval(
+            "input#emailequality",
             (el, config) => (el.value = config.email),
             config
           ),


### PR DESCRIPTION
The email confirmation field of the booking page was not filled in by the script. It is saved under the id `emailequality`. The input has been added to the `index.js` file and a successful booking was performed afterwards.